### PR TITLE
Fixed dim of I-J in Tutorial/BAKR_Tutorial

### DIFF
--- a/Tutorial/BAKR_Tutorial.R
+++ b/Tutorial/BAKR_Tutorial.R
@@ -74,8 +74,8 @@ p = dim(X)[2] #Number of markers or genes
 K_tilde = ApproxGaussKernel(t(X_train),p,p)
 
 ### Center the Approximate Kernel Matrix for numerical stability ###
-v=matrix(1, n, 1)
-M=diag(n)-v%*%t(v)/n
+v=matrix(1, floor(0.8*n), 1)
+M=diag(floor(0.8*n))-v%*%t(v)/floor(0.8*n)
 Kn=M%*%K_tilde%*%M
 Kn=Kn/mean(diag(Kn))
 


### PR DESCRIPTION
Copied from my email to you:

"""
I just wanted to let you know about a minor bug I ran into: on lines 77 and 78 of /Tutorial/BAKR_Tutorial.R, you create the orthogonal projector onto the subspace orthogonal to the one vector, but it's of the dimension to match the full dataset, instead of the training set.

On my computer (Ubuntu 16.04 running R 3.4.1), this results in errors on lines 79 and 80:

[[Begin R output]]
> ...
> ### Center the Approximate Kernel Matrix for numerical stability ###
> v=matrix(1, n, 1)
> M=diag(n)-v%*%t(v)/n
> Kn=M%*%K_tilde%*%M
Error in M %*% K_tilde : non-conformable arguments
> Kn=Kn/mean(diag(Kn))
Error: object 'Kn' not found
[[End R output]]

Replacing "n" with "0.8*n" on lines 77 and 78 resolves the issue.
"""